### PR TITLE
Publishing of rock with tag with major version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Build OpenSearch from source, run tests and release.
 
 env:
-  RELEASE: edge
+  RELEASE: candidate
 
 on:
   push:
@@ -67,3 +67,7 @@ jobs:
               docker-daemon:ghcr.io/canonical/charmed-opensearch:${tag_version}
           
           docker push ghcr.io/canonical/charmed-opensearch:${tag_version}
+          
+          # push major version tag
+          major_tag_version="${base%%.*}-${{ env.RELEASE }}"
+          docker push ghcr.io/canonical/charmed-opensearch:${major_tag_version}

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -19,7 +19,7 @@ platforms: # The platforms this ROCK should be built on and run on
 services:
   start:
     override: replace
-    command: /bin/bash /bin/start.sh
+    command: /bin/start.sh
     environment:
       OPENSEARCH_HOME: /
       OPENSEARCH_JAVA_HOME: /jdk

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -20,6 +20,7 @@ services:
   start:
     override: replace
     command: /bin/start.sh
+    startup: enabled
     environment:
       OPENSEARCH_HOME: /
       OPENSEARCH_JAVA_HOME: /jdk

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -70,4 +70,4 @@ parts:
     organize:
       start.sh: usr/bin/start.sh
     stage:
-      - bin/start.sh
+      - usr/bin/start.sh

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -19,20 +19,19 @@ platforms: # The platforms this ROCK should be built on and run on
 services:
   start:
     override: replace
-    command: "/bin/start.sh"
-
-env:
-  - OPENSEARCH_HOME: /
-  - OPENSEARCH_JAVA_HOME: /jdk
-  - OPENSEARCH_PATH_CONF: /config
-  - OPENSEARCH_TMPDIR: /opensearch-tmp
-  - OPENSEARCH_PLUGINS: /plugins
-  - CLUSTER_NAME: opensearch-dev
-  - NODE_NAME: node-0
-  - NODE_ROLES: cluster_manager,data
-  - INITIAL_CM_NODES: ""
-  - NETWORK_HOST: _local_,_site_
-  - SEED_HOSTS: ""
+    command: /bin/bash /bin/start.sh
+    environment:
+      OPENSEARCH_HOME: /
+      OPENSEARCH_JAVA_HOME: /jdk
+      OPENSEARCH_PATH_CONF: /config
+      OPENSEARCH_TMPDIR: /opensearch-tmp
+      OPENSEARCH_PLUGINS: /plugins
+      CLUSTER_NAME: opensearch-dev
+      NODE_NAME: node-0
+      NODE_ROLES: cluster_manager,data
+      INITIAL_CM_NODES: ""
+      NETWORK_HOST: _local_,_site_
+      SEED_HOSTS: ""
 
 parts:
   opensearch-snap:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,7 +16,10 @@ description: |
 platforms: # The platforms this ROCK should be built on and run on
   amd64:
 
-entrypoint: ["/bin/bash", "/bin/start.sh"]
+services:
+  start:
+    override: replace
+    command: "/bin/start.sh"
 
 env:
   - OPENSEARCH_HOME: /

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -19,7 +19,7 @@ platforms: # The platforms this ROCK should be built on and run on
 services:
   start:
     override: replace
-    command: /bin/start.sh
+    command: /usr/bin/start.sh
     startup: enabled
     environment:
       OPENSEARCH_HOME: /
@@ -68,6 +68,6 @@ parts:
     plugin: dump
     source: scripts
     organize:
-      start.sh: bin/start.sh
+      start.sh: usr/bin/start.sh
     stage:
       - bin/start.sh


### PR DESCRIPTION
This PR:
- bumps the release to `candidate` 
- adds the publishing of the rock under the tag `2-candidate`
- replace the entrypoint by pebble format