### PR TITLE
Release candidate of rock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           sudo snap install --devmode --channel edge skopeo
           
           # rockcraft
-          sudo snap install --classic --channel edge rockcraft --rev=687
+          sudo snap install --classic --channel edge rockcraft --revision=687
           
           # jq and yq
           sudo snap install jq yq

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           sudo snap install --devmode --channel edge skopeo
           
           # rockcraft
-          sudo snap install --classic --channel edge rockcraft
+          sudo snap install --classic --channel edge rockcraft --rev=687
           
           # jq and yq
           sudo snap install jq yq

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           sudo snap install --devmode --channel edge skopeo
           
           # rockcraft
-          sudo snap install --classic --channel edge rockcraft --revision=687
+          sudo snap install rockcraft --classic --edge --revision=687
           
           # jq and yq
           sudo snap install jq yq
@@ -55,9 +55,9 @@ jobs:
           
           sudo apt-get autoremove -y
 
-      - id: build-rock
-        name: Build rock
-        uses: canonical/craft-actions/rockcraft-pack@main
+      - name: Build rock
+        run: |
+          rockcraft pack --verbose
 
       - name: Upload built rock job artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Build OpenSearch from source, run tests and release.
 
 env:
-  RELEASE: edge
+  RELEASE: candidate
 
 on:
   push:
@@ -67,3 +67,7 @@ jobs:
               docker-daemon:ghcr.io/canonical/charmed-opensearch:${tag_version}
           
           docker push ghcr.io/canonical/charmed-opensearch:${tag_version}
+          
+          # push major version tag
+          major_tag_version="${base%%.*}-${{ env.RELEASE }}"
+          docker push ghcr.io/canonical/charmed-opensearch:${major_tag_version}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd charmed-opensearch-rock
 ```
 ### Installing Prerequisites
 ```bash
-sudo snap install rockcraft --edge --classic --rev=687
+sudo snap install rockcraft --edge --classic --revision=687
 sudo snap install docker
 sudo snap install lxd
 sudo snap install skopeo --edge --devmode

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd charmed-opensearch-rock
 ```
 ### Installing Prerequisites
 ```bash
-sudo snap install rockcraft --edge --classic
+sudo snap install rockcraft --edge --classic --rev=687
 sudo snap install docker
 sudo snap install lxd
 sudo snap install skopeo --edge --devmode

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -35,7 +35,7 @@ parts:
   opensearch-snap:
     plugin: nil
     stage-snaps:
-      - opensearch/latest/edge
+      - opensearch/latest/candidate
       - yq
     stage-packages:
       - curl


### PR DESCRIPTION
This PR:
- bumps the release to candidate
- pins the revision of rockcraft 
- adds the publishing of the rock under the tag `2-candidate`

