### PR TITLE
[DPE-6598] Update 2.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       rock-file: ${{ steps.build-snap.outputs.rock }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
           rockcraft pack --verbose
 
       - name: Upload built rock job artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charmed_opensearch_rock_amd64
           path: "charmed-opensearch_*.rock"
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download rock file
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: charmed_opensearch_rock_amd64
           path: .

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -4,7 +4,7 @@ name: charmed-opensearch  # the name of your ROCK
 base: ubuntu@24.04  # the base environment for this ROCK
 license: Apache-2.0
 
-version: '2.17.0' # just for humans. Semantic versioning is recommended
+version: '2.18.0' # just for humans. Semantic versioning is recommended
 
 summary: 'Charmed OpenSearch ROCK OCI.'
 description: |


### PR DESCRIPTION
Updates the CI with newer actions and moves opensearch to 2.18.