### PR TITLE
[CI] Move release.yaml to 2/edge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - main
+      - 2/edge
 
 jobs:
   ci-tests:


### PR DESCRIPTION
This PR moves release.yaml from main branch to 2/edge