### PR TITLE
[Release CI] Fix Docker Issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - test-release-fix-docker-version
+      - 2/edge
 
 jobs:
   ci-tests:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - 2/edge
+      - test-release-fix-docker-version
 
 jobs:
   ci-tests:
@@ -26,7 +26,9 @@ jobs:
       - name: Install required dependencies
         run: |
           # docker
-          sudo snap install docker
+          # FIXME: v27.2.0 reports "...client version 1.22 is too old..." when trying to copy the
+          # rock to the local repository --revision=2932
+          sudo snap install docker --channel=latest/stable --revision=2932
           sudo addgroup --system docker; sudo adduser $USER docker
           newgrp docker
           sudo snap disable docker; sudo snap enable docker

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           version="$(cat rockcraft.yaml | yq .version)"
           
           base="$(cat rockcraft.yaml | yq .base)"
-          base="${base#*:}"
+          base="${base#*@}"
           
           # push major version to edge
           major_tag_version="${version%%.*}-${{ env.RELEASE }}"


### PR DESCRIPTION
Currently, the CI is failing with `docker client 1.22 is too old...` error.

That error has been fixed previously in our rock CI by pinning the docker revision.