### PR TITLE
[DPE-6936] - 2.19.1 release

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,10 +1,10 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: charmed-opensearch  # the name of your ROCK
-base: ubuntu@24.04  # the base environment for this ROCK
+name: charmed-opensearch # the name of your ROCK
+base: ubuntu@24.04 # the base environment for this ROCK
 license: Apache-2.0
 
-version: '2.18.0' # just for humans. Semantic versioning is recommended
+version: '2.19.1' # just for humans. Semantic versioning is recommended
 
 summary: 'Charmed OpenSearch ROCK OCI.'
 description: |
@@ -23,7 +23,7 @@ services:
     override: replace
     startup: enabled
     summary: Start OpenSearch
-    command: "/bin/bash /bin/start.sh"
+    command: '/bin/bash /bin/start.sh'
     environment:
       OPS_ROOT: /opt/opensearch
       OPENSEARCH_HOME: /usr/share/opensearch


### PR DESCRIPTION
* Updated the `version` field from `2.18.0` to `2.19.1`, reflecting a new release of the Charmed OpenSearch ROCK.

Syntax adjustment:

* Changed the quotation style for the `command` field in the `services` section from double quotes to single quotes for consistency.