### PR TITLE
[DPE-7805] Rock derived from slim Opensearch snap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - 2-24.04/edge
+      - 3-24.04
   workflow_call:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ For more information on rocks, visit the [rockcraft Github](https://github.com/c
 ## Version
 The OpenSearch rock release aligns with the [OpenSearch upstream major version](https://opensearch.org/docs/latest/version-history/) naming. OpenSearch releases major versions such as 1.0, 2.0, and so on.
 
-## Release
-Charmed OpenSearch [Rock Release Notes](https://discourse.charmhub.io/t/release-notes-charmed-opensearch-2-rock/10278).
-
-
 ## Rock Usage
 ### Building the Rock
 The steps outlined below are based on the assumption that you are building the rock with the latest LTS of Ubuntu.  

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -4,7 +4,7 @@ name: opensearch # the name of your ROCK
 base: ubuntu@24.04 # the base environment for this ROCK
 license: Apache-2.0
 
-version: '2.19.2' # just for humans. Semantic versioning is recommended
+version: '3.1.0' # just for humans. Semantic versioning is recommended
 
 summary: 'OpenSearch ROCK OCI.'
 description: |
@@ -48,7 +48,7 @@ parts:
   opensearch-snap:
     plugin: nil
     stage-snaps:
-      - opensearch/2/edge
+      - opensearch/3/edge/dpe-7403
     stage-packages:
       - base-files
       - python3-venv

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -48,7 +48,7 @@ parts:
   opensearch-snap:
     plugin: nil
     stage-snaps:
-      - opensearch/3/edge/dpe-7403
+      - opensearch/3/edge
     stage-packages:
       - base-files
       - python3-venv

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -85,6 +85,7 @@ set_yaml_prop "${conf}" "path.data" "${OPENSEARCH_VARLIB}/data"
 set_yaml_prop "${conf}" "path.logs" "${OPENSEARCH_VARLOG}/logs"
 set_yaml_prop "${conf}" "plugins.security.disabled" "true"
 sed -i "s@=logs/@=${OPENSEARCH_VARLOG}/@" "${OPENSEARCH_PATH_CONF}/jvm.options"
+sed -i "s@-javaagent:@-javaagent:/@" "${OPENSEARCH_PATH_CONF}/jvm.options"
 
 cat "${conf}"
 


### PR DESCRIPTION
This PR:
- Bumps the version to 3.1.0
- Updates the release workflow trigger branch
- Removes irrelevant release notes link from the README
- Sets the javaagent path in the start script

Addresses [DPE-7805]


[DPE-7805]: https://warthogs.atlassian.net/browse/DPE-7805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ