### PR TITLE
Restore binaries and set environment vars

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,3 +226,24 @@ jobs:
           if [ "${all_nodes}" != "cm0,cm1,data1" ]; then
               exit 1
           fi
+
+      - name: Ensure expected plugins are available
+        env:
+          OPENSEARCH_BIN: /usr/share/opensearch/bin
+        run: |
+          # expected plugins appear in plugins listing
+          check_plugin_exists() {
+            local plugin=$1
+            docker exec cm0 bash -c "${OPENSEARCH_BIN}/opensearch-plugin list | grep $plugin" || exit 1
+          }
+
+          check_plugin_exists "prometheus-exporter"
+          check_plugin_exists "repository-s3"
+          check_plugin_exists "repository-gcs"
+          check_plugin_exists "repository-azure"
+
+          # Prometheus exporter can be queried
+          resp=$(curl -I -XGET http://localhost:9200/_prometheus/metrics)
+          if [[ "$resp" != *"200 OK"* ]]; then
+            exit 1
+          fi

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,31 +18,31 @@ platforms: # The platforms this ROCK should be built on and run on
 
 run_user: _daemon_
 
+environment:
+  OPENSEARCH_HOME: /usr/share/opensearch
+
+  JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
+  OPENSEARCH_JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
+  OPENSEARCH_BIN: /usr/share/opensearch/bin
+  OPENSEARCH_LIB: /usr/share/opensearch/lib
+  OPENSEARCH_PLUGINS: /usr/share/opensearch/plugins
+  OPENSEARCH_MODULES: /usr/share/opensearch/modules
+
+  OPENSEARCH_PATH_CONF: /etc/opensearch
+  OPENSEARCH_PATH_CERTS: /etc/opensearch/certificates
+
+  OPENSEARCH_VARLIB: /var/lib/opensearch
+  OPENSEARCH_TMPDIR: /usr/share/tmp
+  OPENSEARCH_VARLOG: /var/log/opensearch
+
+  KNN_LIB_DIR: /usr/share/opensearch/plugins/opensearch-knn/lib
+
 services:
   opensearch:
     override: replace
     startup: enabled
     summary: Start OpenSearch
     command: '/bin/bash /bin/start.sh'
-    environment:
-      OPS_ROOT: /opt/opensearch
-      OPENSEARCH_HOME: /usr/share/opensearch
-
-      JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
-      OPENSEARCH_JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
-      OPENSEARCH_BIN: /usr/share/opensearch/bin
-      OPENSEARCH_LIB: /usr/share/opensearch/lib
-      OPENSEARCH_PLUGINS: /usr/share/opensearch/plugins
-      OPENSEARCH_MODULES: /usr/share/opensearch/modules
-
-      OPENSEARCH_PATH_CONF: /etc/opensearch
-      OPENSEARCH_PATH_CERTS: /etc/opensearch/certificates
-
-      OPENSEARCH_VARLIB: /var/lib/opensearch
-      OPENSEARCH_TMPDIR: /usr/share/tmp
-      OPENSEARCH_VARLOG: /var/log/opensearch
-
-      KNN_LIB_DIR: /usr/share/opensearch/plugins/opensearch-knn/lib
 
 parts:
   opensearch-snap:
@@ -65,6 +65,10 @@ parts:
       # enable security monitoring
       rocks=usr/share/rocks/
       mkdir -p ${rocks}
+
+      # move original plugin and keystore binary
+      mv "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-plugin.orig" "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-plugin"
+      mv "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-keystore.orig" "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-keystore"
 
       ## for deb packages
       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W > ${rocks}/dpkg.query


### PR DESCRIPTION
This PR:
- ensures the expected environment variables are available to cli tools that are not part of a service
- restores the binaries that were [renamed in the snap](https://github.com/canonical/opensearch-snap/blob/7bfaef06e4488b928446cfced3462195d1d13cd7/snap/snapcraft.yaml#L323)