### PR TITLE
DPE-8937: ensure user exists with right UID and certificates directories exist with correct permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,10 +84,8 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'
-          # Pin to post-incident release (Trivy 2026-03-01; releases 0.27.0-0.69.1 were deleted)
+          # Pin to post-incident release (Trivy 2026-03-01)
           version: 'v0.69.3'
-          # helps avoid GitHub API rate limits
-          github-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
           github-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -125,7 +125,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Download rock file
+      - name: Download rock filehas_duplicate_env
         uses: actions/download-artifact@v4
         with:
           name: opensearch_rock_amd64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,8 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'
+          # Pin to post-incident release (Trivy 2026-03-01; releases 0.27.0-0.69.1 were deleted)
+          version: 'v0.69.3'
           # helps avoid GitHub API rate limits
           github-pat: ${{ secrets.GITHUB_TOKEN }}
 
@@ -103,6 +105,8 @@ jobs:
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           severity: "MEDIUM,HIGH,CRITICAL"
           scanners: "vuln"
+          # Pin to post-incident release (Trivy 2026-03-01)
+          version: 'v0.69.3'
       
       - name: Upload trivy report as a Github artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,8 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'
+          # helps avoid GitHub API rate limits
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Download rock filehas_duplicate_env
+      - name: Download rock file
         uses: actions/download-artifact@v4
         with:
           name: opensearch_rock_amd64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
           severity: 'MEDIUM,HIGH,CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -86,7 +86,7 @@ parts:
       # Ensure _daemon_ user has UID/GID 584792 for Pebble service
       # Pebble's user field requires a username in /etc/passwd, not just a numeric UID
       # _daemon_ is the default run_user, so we ensure it has the correct UID to match file ownership
-      # If _daemon_ doesn't exist or has wrong UID, recreate it with UID 584792
+      # If _daemon_ does not exist or has wrong UID, recreate it with UID 584792
       if ! id -u _daemon_ >/dev/null 2>&1 || [ "$(id -u _daemon_)" != "584792" ]; then
         # Remove existing _daemon_ user/group if it has wrong UID
         userdel _daemon_ 2>/dev/null || true
@@ -104,18 +104,7 @@ parts:
       mkdir -p etc/opensearch/certificates
       chown -R 584792:584792 etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
       chmod 750 etc/opensearch/certificates
-      
-      # Ensure securityadmin.sh and other OpenSearch scripts are executable
-      if [ -f usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh ]; then
-        chmod +x usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh
-      fi
-      # Ensure opensearch-plugin and opensearch-keystore are executable
-      if [ -f usr/share/opensearch/bin/opensearch-plugin ]; then
-        chmod +x usr/share/opensearch/bin/opensearch-plugin
-      fi
-      if [ -f usr/share/opensearch/bin/opensearch-keystore ]; then
-        chmod +x usr/share/opensearch/bin/opensearch-keystore
-      fi
+
 
   entry:
     plugin: dump

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -83,15 +83,9 @@ parts:
     override-prime: |
       craftctl default
 
-      # Ensure _daemon_ user has UID/GID 584792 for Pebble service
-      # Pebble's user field requires a username in /etc/passwd, not just a numeric UID
-      # _daemon_ is the default run_user, so we ensure it has the correct UID to match file ownership
-      # If _daemon_ does not exist or has wrong UID, recreate it with UID 584792
-      if ! id -u _daemon_ >/dev/null 2>&1 || [ "$(id -u _daemon_)" != "584792" ]; then
-        # Remove existing _daemon_ user/group if it has wrong UID
-        userdel _daemon_ 2>/dev/null || true
-        groupdel _daemon_ 2>/dev/null || true
-        # Create _daemon_ with correct UID/GID
+      # Ensure _daemon_ user exists with UID/GID 584792 for Pebble service
+      # Pebble's user field requires a username in /etc/passwd, not just a numeric UID.
+      if ! id -u _daemon_ >/dev/null 2>&1; then
         groupadd -g 584792 _daemon_ || true
         useradd -u 584792 -g 584792 -r -s /bin/false _daemon_ || true
       fi
@@ -102,11 +96,14 @@ parts:
       # Ensure certificates directory exists with correct permissions
       # This directory is used for TLS certificates (*.p12, chain.pem)
       mkdir -p etc/opensearch/certificates
+
       # Mirror with the snap style: https://github.com/canonical/opensearch-snap/blob/2/edge/snap/hooks/install#L79
       # service user owns the directories/files, group root can also access them when needed.
       chown -R 584792 etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
       chgrp -R root etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
-      chmod 770 etc/opensearch/certificates
+      # Minimum permissions: daemon can write, root can traverse/read.
+      # Setgid so files created by _daemon_ inherit group root without needing group-write on the directory.
+      chmod 2750 etc/opensearch/certificates
 
 
   entry:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -83,9 +83,39 @@ parts:
     override-prime: |
       craftctl default
 
-      # Give permission ot the required folders
+      # Ensure _daemon_ user has UID/GID 584792 for Pebble service
+      # Pebble's user field requires a username in /etc/passwd, not just a numeric UID
+      # _daemon_ is the default run_user, so we ensure it has the correct UID to match file ownership
+      # If _daemon_ doesn't exist or has wrong UID, recreate it with UID 584792
+      if ! id -u _daemon_ >/dev/null 2>&1 || [ "$(id -u _daemon_)" != "584792" ]; then
+        # Remove existing _daemon_ user/group if it has wrong UID
+        userdel _daemon_ 2>/dev/null || true
+        groupdel _daemon_ 2>/dev/null || true
+        # Create _daemon_ with correct UID/GID
+        groupadd -g 584792 _daemon_ || true
+        useradd -u 584792 -g 584792 -r -s /bin/false _daemon_ || true
+      fi
+
+      # Give permission at the required folders
       mkdir -p var/lib/opensearch usr/share/tmp var/log/opensearch
+      
+      # Ensure certificates directory exists with correct permissions
+      # This directory is used for TLS certificates (*.p12, chain.pem)
+      mkdir -p etc/opensearch/certificates
       chown -R 584792:584792 etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
+      chmod 750 etc/opensearch/certificates
+      
+      # Ensure securityadmin.sh and other OpenSearch scripts are executable
+      if [ -f usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh ]; then
+        chmod +x usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh
+      fi
+      # Ensure opensearch-plugin and opensearch-keystore are executable
+      if [ -f usr/share/opensearch/bin/opensearch-plugin ]; then
+        chmod +x usr/share/opensearch/bin/opensearch-plugin
+      fi
+      if [ -f usr/share/opensearch/bin/opensearch-keystore ]; then
+        chmod +x usr/share/opensearch/bin/opensearch-keystore
+      fi
 
   entry:
     plugin: dump

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -102,8 +102,11 @@ parts:
       # Ensure certificates directory exists with correct permissions
       # This directory is used for TLS certificates (*.p12, chain.pem)
       mkdir -p etc/opensearch/certificates
-      chown -R 584792:584792 etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
-      chmod 750 etc/opensearch/certificates
+      # Mirror with the snap style: https://github.com/canonical/opensearch-snap/blob/2/edge/snap/hooks/install#L79
+      # service user owns the directories/files, group root can also access them when needed.
+      chown -R 584792 etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
+      chgrp -R root etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
+      chmod 770 etc/opensearch/certificates
 
 
   entry:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,6 +18,52 @@ function set_yaml_prop() {
     /usr/bin/python3 /usr/bin/set_conf.py --file "${target_file}" --key "${key}" --value "${value}"
 }
 
+function ensure_editable_cacerts_trust_store() {
+    # Create a writable PKCS12 truststore derived from the JDK's read-only cacerts.
+    # this comes from https://github.com/canonical/opensearch-snap/blob/2/edge/snap/hooks/install#L55
+    local dest="${OPENSEARCH_PATH_CERTS}/cacert.p12"
+    local jvm_opts="${OPENSEARCH_PATH_CONF}/jvm.options"
+
+    if [ ! -f "${dest}" ]; then
+        local src=""
+        if [ -f "/etc/ssl/certs/java/cacerts" ]; then
+            src="/etc/ssl/certs/java/cacerts"
+        elif [ -n "${JAVA_HOME:-}" ] && [ -f "${JAVA_HOME}/lib/security/cacerts" ]; then
+            src="${JAVA_HOME}/lib/security/cacerts"
+        fi
+
+        local keytool=""
+        if [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME}/bin/keytool" ]; then
+            keytool="${JAVA_HOME}/bin/keytool"
+        elif command -v keytool >/dev/null 2>&1; then
+            keytool="$(command -v keytool)"
+        fi
+
+        if [ -n "${src}" ] && [ -n "${keytool}" ]; then
+            "${keytool}" \
+                -importkeystore \
+                -srckeystore "${src}" \
+                -destkeystore "${dest}" \
+                -srcstoretype JKS \
+                -deststoretype PKCS12 \
+                -srcstorepass changeit \
+                -deststorepass changeit \
+                -noprompt
+            # keep this truststore editable by both daemon and root (group).
+            chmod 660 "${dest}" || true
+        else
+            echo "Skipping cacert.p12 generation: missing source cacerts or keytool" >&2
+        fi
+    fi
+
+    if [ -f "${jvm_opts}" ]; then
+        grep -q "javax.net.ssl.trustStore=.*cacert.p12" "${jvm_opts}" \
+            || echo "-Djavax.net.ssl.trustStore=${dest}" >> "${jvm_opts}"
+        grep -q "javax.net.ssl.trustStorePassword=changeit" "${jvm_opts}" \
+            || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${jvm_opts}"
+    fi
+}
+
 function network_host() {
     echo "[ \"_site_\", \"$(hostname -i)\" ]"
 }
@@ -70,6 +116,8 @@ function seed_hosts() {
 
 
 conf="${OPENSEARCH_PATH_CONF}/opensearch.yml"
+
+ensure_editable_cacerts_trust_store
 
 set_yaml_prop "${conf}" "cluster.name" "${CLUSTER_NAME}"
 set_yaml_prop "${conf}" "node.name" "${NODE_NAME}"


### PR DESCRIPTION
## Summary

This PR updates the rock build override-prime steps in rockcraft.yaml to ensure the runtime user and filesystem permissions match what Pebble/OpenSearch expects. It aligns the rock image with the snap-style runtime ownership/permissions model so Pebble/OpenSearch can read/write TLS artifacts reliably as the _daemon_ user, while still allowing root to manage/rotate the same files when needed.

## What changed

- Ensure _daemon_ exists with UID/GID `584792`: 
     - if missing or mismatched, remove and recreate `_daemon_` user so Pebble can resolve the username and file ownership aligns with the expected numeric IDs.
- Set OpenSearch runtime paths to _daemon_:root ownership such as:
       chown -R 584792
       chgrp -R root 

- Use chmod 2750 on etc/opensearch/certificates: 
 owner (_daemon_) has full access, group root can read and traverse. Setgid  ensures files created by _daemon_ inherit group root. By this way, root can manage/rotate certs without making the directory group-writable
- Update start.sh: 
ensure_editable_cacerts_trust_store creates cacert.p12 in OPENSEARCH_PATH_CERTS and sets chmod 660 so both _daemon_ and root can update the truststores. This relies on the rock’s certs dir permissions (chmod 2750, _daemon_:root).

## Why

Prevents startup/config failures caused by:
- Pebble requiring a username present in /etc/passwd, not just a numeric UID.
- Fix mismatched permissions/ownership on TLS paths when both _daemon_ and root need to update the same artifacts (CA truststore/chain) over time.