### PR TITLE
patch: Update rockcraft.yaml and Remove the use of skopeo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Install required dependencies
         run: |
+          sudo snap install rockcraft --classic --edge
           sudo snap install docker
           sudo addgroup --system docker
           sudo adduser $USER docker
@@ -127,6 +128,7 @@ jobs:
 
       - name: Install required dependencies
         run: |
+          sudo snap install rockcraft --classic --edge
           sudo snap install docker
           sudo addgroup --system docker
           sudo adduser $USER docker

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,22 +56,18 @@ jobs:
 
       - name: Install required dependencies
         run: |
-          # docker
-          # FIXME: v27.2.0 reports "...client version 1.22 is too old..." when trying to copy the
-          # rock to the local repository --revision=2932
-          sudo snap install docker --channel=latest/stable --revision=2932
-          sudo addgroup --system docker; sudo adduser $USER docker
+          sudo snap install docker
+          sudo addgroup --system docker
+          sudo adduser $USER docker
           newgrp docker
-          sudo snap disable docker; sudo snap enable docker
-          # skopeo
-          sudo snap install --devmode --channel edge skopeo
+
           sudo snap install yq
 
       - name: Create local image
         run: |
           version="$(cat rockcraft.yaml | yq .version)"
 
-          sudo skopeo \
+          rockcraft.skopeo \
               --insecure-policy \
               copy \
               oci-archive:opensearch_${version}_amd64.rock \
@@ -131,23 +127,18 @@ jobs:
 
       - name: Install required dependencies
         run: |
-          # docker
-          # FIXME: v27.2.0 reports "...client version 1.22 is too old..." when trying to copy the
-          # rock to the local repository --revision=2932
-          sudo snap install docker --channel=latest/stable --revision=2932
-          sudo addgroup --system docker; sudo adduser $USER docker
+          sudo snap install docker
+          sudo addgroup --system docker
+          sudo adduser $USER docker
           newgrp docker
-          sudo snap disable docker; sudo snap enable docker
 
-          # skopeo
-          sudo snap install --devmode --channel edge skopeo
           sudo snap install yq
 
       - name: Create local image
         run: |
           version="$(cat rockcraft.yaml | yq .version)"
 
-          sudo skopeo \
+          rockcraft.skopeo \
               --insecure-policy \
               copy \
               oci-archive:opensearch_${version}_amd64.rock \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ cd opensearch-rock
 sudo snap install rockcraft --edge --classic
 sudo snap install docker
 sudo snap install lxd
-sudo snap install skopeo --edge --devmode
 ```
 #### Configuring Prerequisites
 ```bash
@@ -56,7 +55,7 @@ rockcraft pack
 
 version="$(cat rockcraft.yaml | yq .version)"
 
-sudo skopeo --insecure-policy \
+rockcraft.skopeo --insecure-policy \
   copy \
   oci-archive:opensearch_"${version}"_amd64.rock \
   docker-daemon:opensearch:"${version}"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -92,18 +92,61 @@ parts:
 
       # Give permission at the required folders
       mkdir -p var/lib/opensearch usr/share/tmp var/log/opensearch
-      
-      # Ensure certificates directory exists with correct permissions
-      # This directory is used for TLS certificates (*.p12, chain.pem)
       mkdir -p etc/opensearch/certificates
+      install -d -o 584792 -g 584792 -m 770 \
+          etc/opensearch \
+          opt/opensearch \
+          usr/share/opensearch \
+          var/lib/opensearch \
+          usr/share/tmp \
+          var/log/opensearch \
+          etc/opensearch/certificates
 
-      # Mirror with the snap style: https://github.com/canonical/opensearch-snap/blob/2/edge/snap/hooks/install#L79
-      # service user owns the directories/files, group root can also access them when needed.
-      chown -R 584792 etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
-      chgrp -R root etc/opensearch opt/opensearch usr/share/opensearch var/lib/opensearch usr/share/tmp var/log/opensearch
-      # Minimum permissions: daemon can write, root can traverse/read.
-      # Setgid so files created by _daemon_ inherit group root without needing group-write on the directory.
-      chmod 2750 etc/opensearch/certificates
+      # Ensure certificates directory exists with correct permissions
+      dest="etc/opensearch/certificates/cacerts.p12"
+      jvm_opts="etc/opensearch/jvm.options"
+
+      if [ ! -f "etc/opensearch/certificates/cacerts.p12" ]; then
+          src=""
+          if [ -f "etc/ssl/certs/java/cacerts" ]; then
+              src="etc/ssl/certs/java/cacerts"
+          elif [ -f "usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts" ]; then
+              src="usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts"
+          fi
+
+          keytool=""
+          if [ -x "usr/lib/jvm/java-21-openjdk-amd64/bin/keytool" ]; then
+              keytool="usr/lib/jvm/java-21-openjdk-amd64/bin/keytool"
+          elif command -v keytool >/dev/null 2>&1; then
+              keytool="$(command -v keytool)"
+          fi
+
+          if [ -n "${src}" ] && [ -n "${keytool}" ]; then
+              "${keytool}" \
+                  -importkeystore \
+                  -srckeystore "${src}" \
+                  -destkeystore "${dest}" \
+                  -srcstoretype JKS \
+                  -deststoretype PKCS12 \
+                  -srcstorepass changeit \
+                  -deststorepass changeit \
+                  -noprompt
+
+              chmod 660 "${dest}"
+              
+          else
+              echo "Skipping cacerts.p12 generation: missing source cacerts or keytool" >&2
+          fi
+      fi
+
+      if [ -f "${jvm_opts}" ]; then
+          grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${jvm_opts}" \
+              || echo "-Djavax.net.ssl.trustStore=${dest}" >> "${jvm_opts}"
+          grep -q "javax.net.ssl.trustStorePassword=changeit" "${jvm_opts}" \
+              || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${jvm_opts}"
+      fi
+      # Set ownership for the configuration directory
+      chown -R 584792:584792 etc/opensearch/
 
 
   entry:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,52 +18,6 @@ function set_yaml_prop() {
     /usr/bin/python3 /usr/bin/set_conf.py --file "${target_file}" --key "${key}" --value "${value}"
 }
 
-function ensure_editable_cacerts_trust_store() {
-    # Create a writable PKCS12 truststore derived from the JDK's read-only cacerts.
-    # this comes from https://github.com/canonical/opensearch-snap/blob/2/edge/snap/hooks/install#L55
-    local dest="${OPENSEARCH_PATH_CERTS}/cacert.p12"
-    local jvm_opts="${OPENSEARCH_PATH_CONF}/jvm.options"
-
-    if [ ! -f "${dest}" ]; then
-        local src=""
-        if [ -f "/etc/ssl/certs/java/cacerts" ]; then
-            src="/etc/ssl/certs/java/cacerts"
-        elif [ -n "${JAVA_HOME:-}" ] && [ -f "${JAVA_HOME}/lib/security/cacerts" ]; then
-            src="${JAVA_HOME}/lib/security/cacerts"
-        fi
-
-        local keytool=""
-        if [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME}/bin/keytool" ]; then
-            keytool="${JAVA_HOME}/bin/keytool"
-        elif command -v keytool >/dev/null 2>&1; then
-            keytool="$(command -v keytool)"
-        fi
-
-        if [ -n "${src}" ] && [ -n "${keytool}" ]; then
-            "${keytool}" \
-                -importkeystore \
-                -srckeystore "${src}" \
-                -destkeystore "${dest}" \
-                -srcstoretype JKS \
-                -deststoretype PKCS12 \
-                -srcstorepass changeit \
-                -deststorepass changeit \
-                -noprompt
-            # keep this truststore editable by both daemon and root (group).
-            chmod 660 "${dest}" || true
-        else
-            echo "Skipping cacert.p12 generation: missing source cacerts or keytool" >&2
-        fi
-    fi
-
-    if [ -f "${jvm_opts}" ]; then
-        grep -q "javax.net.ssl.trustStore=.*cacert.p12" "${jvm_opts}" \
-            || echo "-Djavax.net.ssl.trustStore=${dest}" >> "${jvm_opts}"
-        grep -q "javax.net.ssl.trustStorePassword=changeit" "${jvm_opts}" \
-            || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${jvm_opts}"
-    fi
-}
-
 function network_host() {
     echo "[ \"_site_\", \"$(hostname -i)\" ]"
 }
@@ -116,8 +70,6 @@ function seed_hosts() {
 
 
 conf="${OPENSEARCH_PATH_CONF}/opensearch.yml"
-
-ensure_editable_cacerts_trust_store
 
 set_yaml_prop "${conf}" "cluster.name" "${CLUSTER_NAME}"
 set_yaml_prop "${conf}" "node.name" "${NODE_NAME}"


### PR DESCRIPTION
This Pull Request includes two main updates:
- Remove the use and installation of `skopeo` snap since it is no longer maintained [ref](https://snapcraft.io/skopeo). We use `rockcraft.skopeo` instead.
- Move function that create directories and initialize the java truststore to the rockcraft part since having it in the `start.sh` means it might be not run. There is also some small changes to make sure the charm can work with non-root user.