### PR TITLE
patch: Fix release.yaml to use latest docker and skopeo from rockcraft

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
       - name: Install required dependencies
         run: |
           # docker
-          sudo snap install docker --channel=latest/stable --revision=2932
           sudo snap install docker
           sudo addgroup --system docker
           sudo adduser $USER docker

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,16 +27,12 @@ jobs:
       - name: Install required dependencies
         run: |
           # docker
-          # FIXME: v27.2.0 reports "...client version 1.22 is too old..." when trying to copy the
-          # rock to the local repository --revision=2932
           sudo snap install docker --channel=latest/stable --revision=2932
-          sudo addgroup --system docker; sudo adduser $USER docker
+          sudo snap install docker
+          sudo addgroup --system docker
+          sudo adduser $USER docker
           newgrp docker
-          sudo snap disable docker; sudo snap enable docker
-
-          # skopeo
-          sudo snap install --devmode --channel edge skopeo
-          
+  
           # yq
           sudo snap install yq
 
@@ -62,7 +58,7 @@ jobs:
           
           # push major version to edge
           major_tag_version="${version%%.*}-${{ env.RELEASE }}"
-          sudo skopeo \
+          rockcraft.skopeo \
               --insecure-policy \
               copy \
               oci-archive:opensearch_${version}_amd64.rock \
@@ -72,7 +68,7 @@ jobs:
           ### push full version to edge
           tag_version="${version}-${base}_${{ env.RELEASE }}"
           echo "Publishing opensearch:${tag_version}"
-          sudo skopeo \
+          rockcraft.skopeo \
               --insecure-policy \
               copy \
               oci-archive:opensearch_${version}_amd64.rock \


### PR DESCRIPTION
This Pull Request fixes the `release.yaml` workflow by using the `docker` snap from `stable` channel instead of fixed revision which was a temporary fix to incompatible version between docker and skopeo. The PR also add use of `rockcraft.skopeo` instead of `skopeo`.