### PR TITLE
patch: Add snap install rockcraft to unblock the release CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,7 +164,7 @@ jobs:
               -p 9200:9200 \
               --name cm0 \
               opensearch:"${version}")
-          container_0_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_0_id}")
+          container_0_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${container_0_id}")
 
           # wait a bit for it to fully initialize
           sleep 30s
@@ -178,7 +178,7 @@ jobs:
               -p 9201:9200 \
               --name data1 \
               opensearch:"${version}")
-          container_1_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_1_id}")
+          container_1_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${container_1_id}")
 
           # wait a bit for it to fully initialize
           sleep 30s
@@ -192,7 +192,7 @@ jobs:
               -p 9202:9200 \
               --name cm1 \
               opensearch:"${version}")
-          container_2_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${container_2_id}")
+          container_2_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${container_2_id}")
 
           # wait a bit for it to fully initialize
           sleep 30s

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           # docker
           sudo snap install docker
+          sudo snap install rockcraft --classic --edge
           sudo addgroup --system docker
           sudo adduser $USER docker
           newgrp docker


### PR DESCRIPTION
This pull request add a step in the `release.yaml` github workflow to install `rockcraft` which was missing in the previous PR #54 . 