### PR TITLE
fix: Fix ca truststore path

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -4,16 +4,17 @@ name: opensearch # the name of your ROCK
 base: ubuntu@24.04 # the base environment for this ROCK
 license: Apache-2.0
 
-version: '2.19.4' # just for humans. Semantic versioning is recommended
+version: "2.19.4" # just for humans. Semantic versioning is recommended
 
-summary: 'OpenSearch ROCK OCI.'
+summary: "OpenSearch ROCK OCI."
 description: |
   OpenSearch is a community-driven, Apache 2.0-licensed open source search and 
   analytics suite that makes it easy to ingest, search, visualize, and analyze data. 
   Developers build with OpenSearch for use cases such as application search, 
   log analytics, data observability, data ingestion, and more.
 
-platforms: # The platforms this ROCK should be built on and run on
+platforms:
+  # The platforms this ROCK should be built on and run on
   amd64:
 
 run_user: _daemon_
@@ -42,7 +43,7 @@ services:
     override: replace
     startup: enabled
     summary: Start OpenSearch
-    command: '/bin/bash /bin/start.sh'
+    command: "/bin/bash /bin/start.sh"
 
 parts:
   opensearch-snap:
@@ -79,7 +80,7 @@ parts:
 
   non-root-user:
     plugin: nil
-    after: [opensearch-snap]
+    after: [ opensearch-snap ]
     override-prime: |
       craftctl default
 
@@ -141,13 +142,12 @@ parts:
 
       if [ -f "${jvm_opts}" ]; then
           grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${jvm_opts}" \
-              || echo "-Djavax.net.ssl.trustStore=${dest}" >> "${jvm_opts}"
+              || echo "-Djavax.net.ssl.trustStore=/${dest}" >> "${jvm_opts}"
           grep -q "javax.net.ssl.trustStorePassword=changeit" "${jvm_opts}" \
               || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${jvm_opts}"
       fi
       # Set ownership for the configuration directory
-      chown -R 584792:584792 etc/opensearch/
-
+      chown -R 584792:584792 /etc/opensearch/
 
   entry:
     plugin: dump

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -85,14 +85,14 @@ parts:
     override-prime: |
       craftctl default
 
-      # Ensure _daemon_ user exists with UID/GID 584792 for Pebble service
-      # Pebble's user field requires a username in /etc/passwd, not just a numeric UID.
+      # --- Daemon user ---
+      # Pebble's run_user requires a named user in /etc/passwd, not just a UID.
       if ! id -u _daemon_ >/dev/null 2>&1; then
         groupadd -g 584792 _daemon_ || true
         useradd -u 584792 -g 584792 -r -s /bin/false _daemon_ || true
       fi
 
-      # Give permission at the required folders
+      # --- Directory permissions ---
       mkdir -p /var/lib/opensearch /usr/share/tmp /var/log/opensearch
       mkdir -p /etc/opensearch/certificates
       install -d -o 584792 -g 584792 -m 770 \
@@ -104,6 +104,7 @@ parts:
           "${CRAFT_PRIME}/var/log/opensearch" \
           "${CRAFT_PRIME}/etc/opensearch/certificates"
 
+      # --- k-NN native libraries ---
       KNN_LIB_DIR="/usr/share/opensearch/plugins/opensearch-knn/lib"
       PRIME_KNN_LIB_DIR="${CRAFT_PRIME}${KNN_LIB_DIR}"
 
@@ -111,24 +112,21 @@ parts:
       find "${PRIME_KNN_LIB_DIR}" -type d -exec chmod 755 {} \;
       find "${PRIME_KNN_LIB_DIR}" -type f -name '*.so*' -exec chmod 755 {} \;
 
-      # Symlink the k-NN libraries into a trusted system path (/usr/lib).
-      # This bypasses the LD_LIBRARY_PATH stripping that occurs when
-      # OpenSearch runs with elevated memory lock capabilities.
+      # Symlink into /usr/lib so the dynamic linker finds them without LD_LIBRARY_PATH,
+      # which is stripped when OpenSearch runs with elevated memory lock capabilities.
       mkdir -p "${CRAFT_PRIME}/usr/lib"
       for FILE in "${PRIME_KNN_LIB_DIR}"/*.so*; do
           ln -sf "${KNN_LIB_DIR}/$(basename "${FILE}")" "${CRAFT_PRIME}/usr/lib/"
       done
 
+      # --- CA truststore ---
       CONTAINER_CONF_DIR="/etc/opensearch"
       PRIME_CONF_DIR="${CRAFT_PRIME}${CONTAINER_CONF_DIR}"
-      CONTAINER_CERTS_DIR="${CONTAINER_CONF_DIR}/certificates"
       CACERTS_DEST="${PRIME_CONF_DIR}/certificates/cacerts.p12"
-      CACERTS="/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts"
-      KEYTOOL="/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool"
 
-      "${KEYTOOL}" \
+      /usr/lib/jvm/java-21-openjdk-amd64/bin/keytool \
           -importkeystore \
-          -srckeystore "${CACERTS}" \
+          -srckeystore /usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts \
           -destkeystore "${CACERTS_DEST}" \
           -srcstoretype JKS \
           -deststoretype PKCS12 \
@@ -138,21 +136,13 @@ parts:
 
       chmod 660 "${CACERTS_DEST}"
 
-
-      #########
-      # Copy JDK cacerts
-
+      # --- JVM options ---
       JVM_OPTS="${PRIME_CONF_DIR}/jvm.options"
-      CONTAINER_CERT_DEST="${CONTAINER_CERTS_DIR}/cacerts.p12"
       JAVA_LIBRARY_PATH="${KNN_LIB_DIR}:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib"
 
-      grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${JVM_OPTS}" \
-          || echo "-Djavax.net.ssl.trustStore=${CONTAINER_CERT_DEST}" >> "${JVM_OPTS}"
-      grep -q "javax.net.ssl.trustStorePassword=changeit" "${JVM_OPTS}" \
-          || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${JVM_OPTS}"
-      grep -q "java.library.path=.*opensearch-knn/lib" "${JVM_OPTS}" \
-          || echo "-Djava.library.path=${JAVA_LIBRARY_PATH}" >> "${JVM_OPTS}"
-      # Set ownership for the configuration directory
+      echo "-Djavax.net.ssl.trustStore=${CONTAINER_CONF_DIR}/certificates/cacerts.p12" >> "${JVM_OPTS}"
+      echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${JVM_OPTS}"
+      echo "-Djava.library.path=${JAVA_LIBRARY_PATH}" >> "${JVM_OPTS}"
       chown -R 584792:584792 "${PRIME_CONF_DIR}"
 
   entry:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -123,10 +123,11 @@ parts:
       CONTAINER_CONF_DIR="/etc/opensearch"
       PRIME_CONF_DIR="${CRAFT_PRIME}${CONTAINER_CONF_DIR}"
       CACERTS_DEST="${PRIME_CONF_DIR}/certificates/cacerts.p12"
+      PRIME_JAVA_HOME="${CRAFT_PRIME}/usr/lib/jvm/java-21-openjdk-amd64"
 
-      /usr/lib/jvm/java-21-openjdk-amd64/bin/keytool \
+      "${PRIME_JAVA_HOME}/bin/keytool" \
           -importkeystore \
-          -srckeystore /usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts \
+          -srckeystore "${PRIME_JAVA_HOME}/lib/security/cacerts" \
           -destkeystore "${CACERTS_DEST}" \
           -srcstoretype JKS \
           -deststoretype PKCS12 \

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -111,76 +111,76 @@ parts:
           "${CRAFT_PRIME}/etc/opensearch/certificates"
 
       # Ensure certificates directory exists with correct permissions
-      container_conf_dir="/etc/opensearch"
-      prime_conf_dir="${CRAFT_PRIME}${container_conf_dir}"
-      container_certs_dir="${container_conf_dir}/certificates"
-      prime_certs_dir="${prime_conf_dir}/certificates"
-      dest="${container_certs_dir}/cacerts.p12"
-      prime_dest="${prime_certs_dir}/cacerts.p12"
-      jvm_opts="${prime_conf_dir}/jvm.options"
-      knn_lib_dir="/usr/share/opensearch/plugins/opensearch-knn/lib"
-      prime_knn_lib_dir="${CRAFT_PRIME}${knn_lib_dir}"
-      java_library_path="${knn_lib_dir}:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib"
+      CONTAINER_CONF_DIR="/etc/opensearch"
+      PRIME_CONF_DIR="${CRAFT_PRIME}${CONTAINER_CONF_DIR}"
+      CONTAINER_CERTS_DIR="${CONTAINER_CONF_DIR}/certificates"
+      PRIME_CERTS_DIR="${PRIME_CONF_DIR}/certificates"
+      CONTAINER_CERT_DEST="${CONTAINER_CERTS_DIR}/cacerts.p12"
+      PRIME_DEST="${PRIME_CERTS_DIR}/cacerts.p12"
+      JVM_OPTS="${PRIME_CONF_DIR}/jvm.options"
+      KNN_LIB_DIR="/usr/share/opensearch/plugins/opensearch-knn/lib"
+      PRIME_KNN_LIB_DIR="${CRAFT_PRIME}${KNN_LIB_DIR}"
+      JAVA_LIBRARY_PATH="${KNN_LIB_DIR}:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib"
 
-      if [ -d "${prime_knn_lib_dir}" ]; then
-          chown -R 584792:584792 "${prime_knn_lib_dir}"
-          find "${prime_knn_lib_dir}" -type d -exec chmod 755 {} \;
-          find "${prime_knn_lib_dir}" -type f -name '*.so*' -exec chmod 755 {} \;
+      if [ -d "${PRIME_KNN_LIB_DIR}" ]; then
+          chown -R 584792:584792 "${PRIME_KNN_LIB_DIR}"
+          find "${PRIME_KNN_LIB_DIR}" -type d -exec chmod 755 {} \;
+          find "${PRIME_KNN_LIB_DIR}" -type f -name '*.so*' -exec chmod 755 {} \;
 
           # Symlink the k-NN libraries into a trusted system path (/usr/lib).
-          # This bypasses the LD_LIBRARY_PATH stripping that occurs when 
+          # This bypasses the LD_LIBRARY_PATH stripping that occurs when
           # OpenSearch runs with elevated memory lock capabilities.
           mkdir -p "${CRAFT_PRIME}/usr/lib"
-          for file in "${prime_knn_lib_dir}"/*.so*; do
+          for FILE in "${PRIME_KNN_LIB_DIR}"/*.so*; do
               # We use basename to ensure the symlink points to the correct runtime path
-              ln -sf "${knn_lib_dir}/$(basename "${file}")" "${CRAFT_PRIME}/usr/lib/"
+              ln -sf "${KNN_LIB_DIR}/$(basename "${FILE}")" "${CRAFT_PRIME}/usr/lib/"
           done
       fi
 
-      if [ ! -f "${prime_dest}" ]; then
-          src=""
+      if [ ! -f "${PRIME_DEST}" ]; then
+          SRC=""
           if [ -f "/etc/ssl/certs/java/cacerts" ]; then
-              src="/etc/ssl/certs/java/cacerts"
+              SRC="/etc/ssl/certs/java/cacerts"
           elif [ -f "/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts" ]; then
-              src="/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts"
+              SRC="/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts"
           fi
 
-          keytool=""
+          KEYTOOL=""
           if [ -x "/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool" ]; then
-              keytool="/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool"
+              KEYTOOL="/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool"
           elif command -v keytool >/dev/null 2>&1; then
-              keytool="$(command -v keytool)"
+              KEYTOOL="$(command -v keytool)"
           fi
 
-          if [ -n "${src}" ] && [ -n "${keytool}" ]; then
-              "${keytool}" \
+          if [ -n "${SRC}" ] && [ -n "${KEYTOOL}" ]; then
+              "${KEYTOOL}" \
                   -importkeystore \
-                  -srckeystore "${src}" \
-                  -destkeystore "${prime_dest}" \
+                  -srckeystore "${SRC}" \
+                  -destkeystore "${PRIME_DEST}" \
                   -srcstoretype JKS \
                   -deststoretype PKCS12 \
                   -srcstorepass changeit \
                   -deststorepass changeit \
                   -noprompt
 
-              chmod 660 "${prime_dest}"
-              
+              chmod 660 "${PRIME_DEST}"
+
           else
               echo "Skipping cacerts.p12 generation: missing source cacerts or keytool" >&2
           fi
       fi
 
-      if [ -f "${jvm_opts}" ]; then
-          # ${dest} is the container-side path, this is what the JVM sees at runtime
-          grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${jvm_opts}" \
-              || echo "-Djavax.net.ssl.trustStore=${dest}" >> "${jvm_opts}"
-          grep -q "javax.net.ssl.trustStorePassword=changeit" "${jvm_opts}" \
-              || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${jvm_opts}"
-          grep -q "java.library.path=.*opensearch-knn/lib" "${jvm_opts}" \
-              || echo "-Djava.library.path=${java_library_path}" >> "${jvm_opts}"
+      if [ -f "${JVM_OPTS}" ]; then
+          # ${CONTAINER_CERT_DEST} is the container-side path, this is what the JVM sees at runtime
+          grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${JVM_OPTS}" \
+              || echo "-Djavax.net.ssl.trustStore=${CONTAINER_CERT_DEST}" >> "${JVM_OPTS}"
+          grep -q "javax.net.ssl.trustStorePassword=changeit" "${JVM_OPTS}" \
+              || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${JVM_OPTS}"
+          grep -q "java.library.path=.*opensearch-knn/lib" "${JVM_OPTS}" \
+              || echo "-Djava.library.path=${JAVA_LIBRARY_PATH}" >> "${JVM_OPTS}"
       fi
       # Set ownership for the configuration directory
-      chown -R 584792:584792 "${prime_conf_dir}"
+      chown -R 584792:584792 "${PRIME_CONF_DIR}"
 
   entry:
     plugin: dump

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -71,12 +71,6 @@ parts:
       mv "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-plugin.orig" "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-plugin"
       mv "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-keystore.orig" "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-keystore"
 
-      knn_lib_dir="${CRAFT_PRIME}/usr/share/opensearch/plugins/opensearch-knn/lib"
-      knn_avx2_lib="${knn_lib_dir}/libopensearchknn_faiss_avx2.so"
-      if [ ! -f "${knn_avx2_lib}" ]; then
-          echo "Missing OpenSearch k-NN native library: ${knn_avx2_lib}" >&2
-          exit 1
-      fi
 
       ## for deb packages
       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W > ${rocks}/dpkg.query
@@ -122,20 +116,17 @@ parts:
       PRIME_KNN_LIB_DIR="${CRAFT_PRIME}${KNN_LIB_DIR}"
       JAVA_LIBRARY_PATH="${KNN_LIB_DIR}:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib"
 
-      if [ -d "${PRIME_KNN_LIB_DIR}" ]; then
-          chown -R 584792:584792 "${PRIME_KNN_LIB_DIR}"
-          find "${PRIME_KNN_LIB_DIR}" -type d -exec chmod 755 {} \;
-          find "${PRIME_KNN_LIB_DIR}" -type f -name '*.so*' -exec chmod 755 {} \;
+      chown -R 584792:584792 "${PRIME_KNN_LIB_DIR}"
+      find "${PRIME_KNN_LIB_DIR}" -type d -exec chmod 755 {} \;
+      find "${PRIME_KNN_LIB_DIR}" -type f -name '*.so*' -exec chmod 755 {} \;
 
-          # Symlink the k-NN libraries into a trusted system path (/usr/lib).
-          # This bypasses the LD_LIBRARY_PATH stripping that occurs when
-          # OpenSearch runs with elevated memory lock capabilities.
-          mkdir -p "${CRAFT_PRIME}/usr/lib"
-          for FILE in "${PRIME_KNN_LIB_DIR}"/*.so*; do
-              # We use basename to ensure the symlink points to the correct runtime path
-              ln -sf "${KNN_LIB_DIR}/$(basename "${FILE}")" "${CRAFT_PRIME}/usr/lib/"
-          done
-      fi
+      # Symlink the k-NN libraries into a trusted system path (/usr/lib).
+      # This bypasses the LD_LIBRARY_PATH stripping that occurs when
+      # OpenSearch runs with elevated memory lock capabilities.
+      mkdir -p "${CRAFT_PRIME}/usr/lib"
+      for FILE in "${PRIME_KNN_LIB_DIR}"/*.so*; do
+          ln -sf "${KNN_LIB_DIR}/$(basename "${FILE}")" "${CRAFT_PRIME}/usr/lib/"
+      done
 
       if [ ! -f "${PRIME_DEST}" ]; then
           SRC=""

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -123,39 +123,24 @@ parts:
       PRIME_CONF_DIR="${CRAFT_PRIME}${CONTAINER_CONF_DIR}"
       CONTAINER_CERTS_DIR="${CONTAINER_CONF_DIR}/certificates"
       CACERTS_DEST="${PRIME_CONF_DIR}/certificates/cacerts.p12"
+      CACERTS="/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts"
+      KEYTOOL="/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool"
 
-      if [ ! -f "${CACERTS_DEST}" ]; then
-          SRC=""
-          if [ -f "/etc/ssl/certs/java/cacerts" ]; then
-              SRC="/etc/ssl/certs/java/cacerts"
-          elif [ -f "/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts" ]; then
-              SRC="/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts"
-          fi
+      "${KEYTOOL}" \
+          -importkeystore \
+          -srckeystore "${CACERTS}" \
+          -destkeystore "${CACERTS_DEST}" \
+          -srcstoretype JKS \
+          -deststoretype PKCS12 \
+          -srcstorepass changeit \
+          -deststorepass changeit \
+          -noprompt
 
-          KEYTOOL=""
-          if [ -x "/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool" ]; then
-              KEYTOOL="/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool"
-          elif command -v keytool >/dev/null 2>&1; then
-              KEYTOOL="$(command -v keytool)"
-          fi
+      chmod 660 "${CACERTS_DEST}"
 
-          if [ -n "${SRC}" ] && [ -n "${KEYTOOL}" ]; then
-              "${KEYTOOL}" \
-                  -importkeystore \
-                  -srckeystore "${SRC}" \
-                  -destkeystore "${CACERTS_DEST}" \
-                  -srcstoretype JKS \
-                  -deststoretype PKCS12 \
-                  -srcstorepass changeit \
-                  -deststorepass changeit \
-                  -noprompt
 
-              chmod 660 "${CACERTS_DEST}"
-
-          else
-              echo "Skipping cacerts.p12 generation: missing source cacerts or keytool" >&2
-          fi
-      fi
+      #########
+      # Copy JDK cacerts
 
       JVM_OPTS="${PRIME_CONF_DIR}/jvm.options"
       CONTAINER_CERT_DEST="${CONTAINER_CERTS_DIR}/cacerts.p12"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -87,7 +87,7 @@ parts:
 
   non-root-user:
     plugin: nil
-    after: [ opensearch-snap ]
+    after: [opensearch-snap]
     override-prime: |
       craftctl default
 
@@ -102,13 +102,13 @@ parts:
       mkdir -p /var/lib/opensearch /usr/share/tmp /var/log/opensearch
       mkdir -p /etc/opensearch/certificates
       install -d -o 584792 -g 584792 -m 770 \
-          etc/opensearch \
-          opt/opensearch \
-          usr/share/opensearch \
-          var/lib/opensearch \
-          usr/share/tmp \
-          var/log/opensearch \
-          etc/opensearch/certificates
+          "${CRAFT_PRIME}/etc/opensearch" \
+          "${CRAFT_PRIME}/opt/opensearch" \
+          "${CRAFT_PRIME}/usr/share/opensearch" \
+          "${CRAFT_PRIME}/var/lib/opensearch" \
+          "${CRAFT_PRIME}/usr/share/tmp" \
+          "${CRAFT_PRIME}/var/log/opensearch" \
+          "${CRAFT_PRIME}/etc/opensearch/certificates"
 
       # Ensure certificates directory exists with correct permissions
       container_conf_dir="/etc/opensearch"
@@ -171,6 +171,7 @@ parts:
       fi
 
       if [ -f "${jvm_opts}" ]; then
+          # ${dest} is the container-side path, this is what the JVM sees at runtime
           grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${jvm_opts}" \
               || echo "-Djavax.net.ssl.trustStore=${dest}" >> "${jvm_opts}"
           grep -q "javax.net.ssl.trustStorePassword=changeit" "${jvm_opts}" \

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -104,17 +104,8 @@ parts:
           "${CRAFT_PRIME}/var/log/opensearch" \
           "${CRAFT_PRIME}/etc/opensearch/certificates"
 
-      # Ensure certificates directory exists with correct permissions
-      CONTAINER_CONF_DIR="/etc/opensearch"
-      PRIME_CONF_DIR="${CRAFT_PRIME}${CONTAINER_CONF_DIR}"
-      CONTAINER_CERTS_DIR="${CONTAINER_CONF_DIR}/certificates"
-      PRIME_CERTS_DIR="${PRIME_CONF_DIR}/certificates"
-      CONTAINER_CERT_DEST="${CONTAINER_CERTS_DIR}/cacerts.p12"
-      PRIME_DEST="${PRIME_CERTS_DIR}/cacerts.p12"
-      JVM_OPTS="${PRIME_CONF_DIR}/jvm.options"
       KNN_LIB_DIR="/usr/share/opensearch/plugins/opensearch-knn/lib"
       PRIME_KNN_LIB_DIR="${CRAFT_PRIME}${KNN_LIB_DIR}"
-      JAVA_LIBRARY_PATH="${KNN_LIB_DIR}:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib"
 
       chown -R 584792:584792 "${PRIME_KNN_LIB_DIR}"
       find "${PRIME_KNN_LIB_DIR}" -type d -exec chmod 755 {} \;
@@ -128,7 +119,12 @@ parts:
           ln -sf "${KNN_LIB_DIR}/$(basename "${FILE}")" "${CRAFT_PRIME}/usr/lib/"
       done
 
-      if [ ! -f "${PRIME_DEST}" ]; then
+      CONTAINER_CONF_DIR="/etc/opensearch"
+      PRIME_CONF_DIR="${CRAFT_PRIME}${CONTAINER_CONF_DIR}"
+      CONTAINER_CERTS_DIR="${CONTAINER_CONF_DIR}/certificates"
+      CACERTS_DEST="${PRIME_CONF_DIR}/certificates/cacerts.p12"
+
+      if [ ! -f "${CACERTS_DEST}" ]; then
           SRC=""
           if [ -f "/etc/ssl/certs/java/cacerts" ]; then
               SRC="/etc/ssl/certs/java/cacerts"
@@ -147,19 +143,23 @@ parts:
               "${KEYTOOL}" \
                   -importkeystore \
                   -srckeystore "${SRC}" \
-                  -destkeystore "${PRIME_DEST}" \
+                  -destkeystore "${CACERTS_DEST}" \
                   -srcstoretype JKS \
                   -deststoretype PKCS12 \
                   -srcstorepass changeit \
                   -deststorepass changeit \
                   -noprompt
 
-              chmod 660 "${PRIME_DEST}"
+              chmod 660 "${CACERTS_DEST}"
 
           else
               echo "Skipping cacerts.p12 generation: missing source cacerts or keytool" >&2
           fi
       fi
+
+      JVM_OPTS="${PRIME_CONF_DIR}/jvm.options"
+      CONTAINER_CERT_DEST="${CONTAINER_CERTS_DIR}/cacerts.p12"
+      JAVA_LIBRARY_PATH="${KNN_LIB_DIR}:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib"
 
       grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${JVM_OPTS}" \
           || echo "-Djavax.net.ssl.trustStore=${CONTAINER_CERT_DEST}" >> "${JVM_OPTS}"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -161,15 +161,12 @@ parts:
           fi
       fi
 
-      if [ -f "${JVM_OPTS}" ]; then
-          # ${CONTAINER_CERT_DEST} is the container-side path, this is what the JVM sees at runtime
-          grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${JVM_OPTS}" \
-              || echo "-Djavax.net.ssl.trustStore=${CONTAINER_CERT_DEST}" >> "${JVM_OPTS}"
-          grep -q "javax.net.ssl.trustStorePassword=changeit" "${JVM_OPTS}" \
-              || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${JVM_OPTS}"
-          grep -q "java.library.path=.*opensearch-knn/lib" "${JVM_OPTS}" \
-              || echo "-Djava.library.path=${JAVA_LIBRARY_PATH}" >> "${JVM_OPTS}"
-      fi
+      grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${JVM_OPTS}" \
+          || echo "-Djavax.net.ssl.trustStore=${CONTAINER_CERT_DEST}" >> "${JVM_OPTS}"
+      grep -q "javax.net.ssl.trustStorePassword=changeit" "${JVM_OPTS}" \
+          || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${JVM_OPTS}"
+      grep -q "java.library.path=.*opensearch-knn/lib" "${JVM_OPTS}" \
+          || echo "-Djava.library.path=${JAVA_LIBRARY_PATH}" >> "${JVM_OPTS}"
       # Set ownership for the configuration directory
       chown -R 584792:584792 "${PRIME_CONF_DIR}"
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -71,6 +71,13 @@ parts:
       mv "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-plugin.orig" "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-plugin"
       mv "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-keystore.orig" "${CRAFT_PRIME}/usr/share/opensearch/bin/opensearch-keystore"
 
+      knn_lib_dir="${CRAFT_PRIME}/usr/share/opensearch/plugins/opensearch-knn/lib"
+      knn_avx2_lib="${knn_lib_dir}/libopensearchknn_faiss_avx2.so"
+      if [ ! -f "${knn_avx2_lib}" ]; then
+          echo "Missing OpenSearch k-NN native library: ${knn_avx2_lib}" >&2
+          exit 1
+      fi
+
       ## for deb packages
       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W > ${rocks}/dpkg.query
 
@@ -104,10 +111,33 @@ parts:
           etc/opensearch/certificates
 
       # Ensure certificates directory exists with correct permissions
-      dest="/etc/opensearch/certificates/cacerts.p12"
-      jvm_opts="/etc/opensearch/jvm.options"
+      container_conf_dir="/etc/opensearch"
+      prime_conf_dir="${CRAFT_PRIME}${container_conf_dir}"
+      container_certs_dir="${container_conf_dir}/certificates"
+      prime_certs_dir="${prime_conf_dir}/certificates"
+      dest="${container_certs_dir}/cacerts.p12"
+      prime_dest="${prime_certs_dir}/cacerts.p12"
+      jvm_opts="${prime_conf_dir}/jvm.options"
+      knn_lib_dir="/usr/share/opensearch/plugins/opensearch-knn/lib"
+      prime_knn_lib_dir="${CRAFT_PRIME}${knn_lib_dir}"
+      java_library_path="${knn_lib_dir}:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib"
 
-      if [ ! -f "/etc/opensearch/certificates/cacerts.p12" ]; then
+      if [ -d "${prime_knn_lib_dir}" ]; then
+          chown -R 584792:584792 "${prime_knn_lib_dir}"
+          find "${prime_knn_lib_dir}" -type d -exec chmod 755 {} \;
+          find "${prime_knn_lib_dir}" -type f -name '*.so*' -exec chmod 755 {} \;
+
+          # Symlink the k-NN libraries into a trusted system path (/usr/lib).
+          # This bypasses the LD_LIBRARY_PATH stripping that occurs when 
+          # OpenSearch runs with elevated memory lock capabilities.
+          mkdir -p "${CRAFT_PRIME}/usr/lib"
+          for file in "${prime_knn_lib_dir}"/*.so*; do
+              # We use basename to ensure the symlink points to the correct runtime path
+              ln -sf "${knn_lib_dir}/$(basename "${file}")" "${CRAFT_PRIME}/usr/lib/"
+          done
+      fi
+
+      if [ ! -f "${prime_dest}" ]; then
           src=""
           if [ -f "/etc/ssl/certs/java/cacerts" ]; then
               src="/etc/ssl/certs/java/cacerts"
@@ -126,14 +156,14 @@ parts:
               "${keytool}" \
                   -importkeystore \
                   -srckeystore "${src}" \
-                  -destkeystore "${dest}" \
+                  -destkeystore "${prime_dest}" \
                   -srcstoretype JKS \
                   -deststoretype PKCS12 \
                   -srcstorepass changeit \
                   -deststorepass changeit \
                   -noprompt
 
-              chmod 660 "${dest}"
+              chmod 660 "${prime_dest}"
               
           else
               echo "Skipping cacerts.p12 generation: missing source cacerts or keytool" >&2
@@ -145,9 +175,11 @@ parts:
               || echo "-Djavax.net.ssl.trustStore=${dest}" >> "${jvm_opts}"
           grep -q "javax.net.ssl.trustStorePassword=changeit" "${jvm_opts}" \
               || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${jvm_opts}"
+          grep -q "java.library.path=.*opensearch-knn/lib" "${jvm_opts}" \
+              || echo "-Djava.library.path=${java_library_path}" >> "${jvm_opts}"
       fi
       # Set ownership for the configuration directory
-      chown -R 584792:584792 /etc/opensearch/
+      chown -R 584792:584792 "${prime_conf_dir}"
 
   entry:
     plugin: dump

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -92,8 +92,8 @@ parts:
       fi
 
       # Give permission at the required folders
-      mkdir -p var/lib/opensearch usr/share/tmp var/log/opensearch
-      mkdir -p etc/opensearch/certificates
+      mkdir -p /var/lib/opensearch /usr/share/tmp /var/log/opensearch
+      mkdir -p /etc/opensearch/certificates
       install -d -o 584792 -g 584792 -m 770 \
           etc/opensearch \
           opt/opensearch \
@@ -104,20 +104,20 @@ parts:
           etc/opensearch/certificates
 
       # Ensure certificates directory exists with correct permissions
-      dest="etc/opensearch/certificates/cacerts.p12"
-      jvm_opts="etc/opensearch/jvm.options"
+      dest="/etc/opensearch/certificates/cacerts.p12"
+      jvm_opts="/etc/opensearch/jvm.options"
 
-      if [ ! -f "etc/opensearch/certificates/cacerts.p12" ]; then
+      if [ ! -f "/etc/opensearch/certificates/cacerts.p12" ]; then
           src=""
-          if [ -f "etc/ssl/certs/java/cacerts" ]; then
-              src="etc/ssl/certs/java/cacerts"
-          elif [ -f "usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts" ]; then
-              src="usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts"
+          if [ -f "/etc/ssl/certs/java/cacerts" ]; then
+              src="/etc/ssl/certs/java/cacerts"
+          elif [ -f "/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts" ]; then
+              src="/usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts"
           fi
 
           keytool=""
-          if [ -x "usr/lib/jvm/java-21-openjdk-amd64/bin/keytool" ]; then
-              keytool="usr/lib/jvm/java-21-openjdk-amd64/bin/keytool"
+          if [ -x "/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool" ]; then
+              keytool="/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool"
           elif command -v keytool >/dev/null 2>&1; then
               keytool="$(command -v keytool)"
           fi
@@ -142,7 +142,7 @@ parts:
 
       if [ -f "${jvm_opts}" ]; then
           grep -q "javax.net.ssl.trustStore=.*cacerts.p12" "${jvm_opts}" \
-              || echo "-Djavax.net.ssl.trustStore=/${dest}" >> "${jvm_opts}"
+              || echo "-Djavax.net.ssl.trustStore=${dest}" >> "${jvm_opts}"
           grep -q "javax.net.ssl.trustStorePassword=changeit" "${jvm_opts}" \
               || echo "-Djavax.net.ssl.trustStorePassword=changeit" >> "${jvm_opts}"
       fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -68,20 +68,6 @@ function seed_hosts() {
     echo "[ ${formatted_hosts} ]"
 }
 
-if [ -d "${OPENSEARCH_PLUGINS}/opensearch-knn" ]; then
-    if [ ! -d "${KNN_LIB_DIR}" ]; then
-        echo "Missing OpenSearch k-NN native library directory: ${KNN_LIB_DIR}" >&2
-        exit 1
-    fi
-
-    if [ ! -f "${KNN_LIB_DIR}/libopensearchknn_faiss_avx2.so" ]; then
-        echo "Missing OpenSearch k-NN native library: ${KNN_LIB_DIR}/libopensearchknn_faiss_avx2.so" >&2
-        exit 1
-    fi
-
-    existing_ld_library_path="${LD_LIBRARY_PATH:-}"
-    export LD_LIBRARY_PATH="${KNN_LIB_DIR}${existing_ld_library_path:+:${existing_ld_library_path}}"
-fi
 
 conf="${OPENSEARCH_PATH_CONF}/opensearch.yml"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -68,6 +68,20 @@ function seed_hosts() {
     echo "[ ${formatted_hosts} ]"
 }
 
+if [ -d "${OPENSEARCH_PLUGINS}/opensearch-knn" ]; then
+    if [ ! -d "${KNN_LIB_DIR}" ]; then
+        echo "Missing OpenSearch k-NN native library directory: ${KNN_LIB_DIR}" >&2
+        exit 1
+    fi
+
+    if [ ! -f "${KNN_LIB_DIR}/libopensearchknn_faiss_avx2.so" ]; then
+        echo "Missing OpenSearch k-NN native library: ${KNN_LIB_DIR}/libopensearchknn_faiss_avx2.so" >&2
+        exit 1
+    fi
+
+    existing_ld_library_path="${LD_LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="${KNN_LIB_DIR}${existing_ld_library_path:+:${existing_ld_library_path}}"
+fi
 
 conf="${OPENSEARCH_PATH_CONF}/opensearch.yml"
 


### PR DESCRIPTION
* **Added a leading slash to the `trustStore` path in the JVM options to ensure the correct absolute path is used.**
* **Corrected the path for the ownership command from `etc/opensearch/` to `/etc/opensearch/` to properly set permissions on the configuration directory.**
* Standardized the use of double quotes for `version`, `summary`, and `command` fields in `rockcraft.yaml` for consistency and YAML best practices. [[1]](diffhunk://#diff-67c464bbed217d3d422ddd2db32d89360c18ce8584542858e61f3f842c6fb432L7-R17) [[2]](diffhunk://#diff-67c464bbed217d3d422ddd2db32d89360c18ce8584542858e61f3f842c6fb432L45-R46)
* Improved comments and formatting in the `platforms` section for clarity.