### PR TITLE
patch: add missing permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,8 @@ jobs:
     timeout-minutes: 120
     needs:
       - build
+    permissions:
+      security-events: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Add missing permissions as indicated by failure [here](https://github.com/canonical/opensearch-rock/actions/runs/27682598217/job/83185705547):
```
Error: Resource not accessible by integration - https://docs.github.com/rest
  Warning: This run of the CodeQL Action does not have permission to access the CodeQL Action API endpoints. This could be because the Action is running on a pull request from a fork. If not, please ensure the workflow has at least the 'security-events: read' permission. Details: Resource not accessible by integration - https://docs.github.com/rest
```
